### PR TITLE
Remove redundant npm dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "mysql": "^2.16.0",
     "nodejs": "^0.0.0",
     "nodemailer": "^5.1.1",
-    "npm": "^6.7.0",
     "popups": "^1.1.3",
     "smtp-server": "^3.5.0",
     "uuid": "^3.3.2"


### PR DESCRIPTION

Hello chandu5160!

It seems like you have npm as one of your (dev-) dependency in Fesh.
Since you actually need npm to install the dependencies it's redundant to
have npm itself as (dev-) dependency. 

Therefore I've removed it and made this PR, merge if you want :)
Be sure to re-run `npm i` or `yarn` to actualize your lock files.

Beep boop, I'm a bot.
